### PR TITLE
AppleII: fix link to wiki in README for hardware

### DIFF
--- a/AppleII/FujiApple-Rev1.1/README.md
+++ b/AppleII/FujiApple-Rev1.1/README.md
@@ -6,7 +6,7 @@ Minor changes from Rev1:
  * Right angle buttons for accessibility from top edge in vertical position
  * Replace Q1 with equivalent, more widely available and larger part
 
-Usage and software information is available in the [Apple II FujiNet Quickstart Guide](https://github.com/FujiNetWIFI/fujinet-platformio/wiki/AppleII-FujiNet-Quickstart-Guide) page on the [wiki](https://github.com/FujiNetWIFI/fujinet-platformio/wiki/).
+Usage and software information is available in the [Apple II FujiNet Quickstart Guide](https://github.com/FujiNetWIFI/fujinet-firmware/wiki/AppleII-%26-III-FujiNet-Quickstart-Guide) page on the [wiki](https://github.com/FujiNetWIFI/fujinet-platformio/wiki/).
 
 ![FujiApple Rev1 Complete Kit](FujiApple-Rev1-Kit.png)
 
@@ -16,7 +16,7 @@ This project is released under the CERN OHL v2.0.
 
 # PCB
 
-PCB's can be ordered by submitting the files from the _Gerbers_ directory to the fab house of your choice. The design was created using [Diptrace 3.3.1.3](https://diptrace.com).
+PCBs can be ordered by submitting the files from the _Gerbers_ directory to the fab house of your choice. The design was created using [Diptrace 3.3.1.3](https://diptrace.com).
 
 # Bill of Materials (BOM)
 


### PR DESCRIPTION
The wiki page has been moved so I updated the link. Thanks!