### PR TITLE
Fix images of old hardware versions

### DIFF
--- a/AppleII/Old/DB-19M-Adapter-Female-Rev1/README.md
+++ b/AppleII/Old/DB-19M-Adapter-Female-Rev1/README.md
@@ -2,7 +2,7 @@
 
 This adapter was created to be used with FujiNet Rev1
 
-<img src="https://github.com/FujiNetWIFI/fujinet-hardware/blob/master/AppleII/DB-19M-Adapter/images/DB19M_to_IDC20_Adapter.png" width="400px">
+[<img src="images/DB19M_to_IDC20_Adapter.png" width="400px" />](images/DB19M_to_IDC20_Adapter.png)
 
 # License
 
@@ -17,8 +17,8 @@ This project is released under the CERN OHL v2.0.
 
 Insert the 19 pins for the DB-19 socket into a DB-19 or DB-25 cable/adapter with the "fins" of the pins as shown below
 
-<img src="https://github.com/FujiNetWIFI/fujinet-hardware/blob/master/AppleII/DB-19M-Adapter/images/DB19M_to_IDC20_Pin-Alignment.png" width="300px">
-<img src="https://github.com/FujiNetWIFI/fujinet-hardware/blob/master/AppleII/DB-19M-Adapter/images/IMG_20221002_145542.jpg" width="300px">
+[<img src="images/DB19M_to_IDC20_Pin-Alignment.png" width="300px" />](images/DB19M_to_IDC20_Pin-Alignment.png)
+[<img src="images/IMG_20221002_145542.jpg" width="300px" />](images/IMG_20221002_145542.jpg)
 
 The PCB is labeled "PIN SIDE" which is where the 3D printed connector goes. The unlabled side of the PCB is the solder side. Solder pin 1 and pin 19 first, ensuring the pins are straight/flush with the PCB then solder the remaining pins. Use side cutters to remove excess pins from the solder side.
 

--- a/AppleII/Old/DB-19M-Adapter-Male-Rev00/README.md
+++ b/AppleII/Old/DB-19M-Adapter-Male-Rev00/README.md
@@ -2,7 +2,7 @@
 
 This adapter was created to be used with FujiNet but is likely usable for other Apple II DB-19 devices
 
-<img src="https://github.com/FujiNetWIFI/fujinet-hardware/blob/master/AppleII/DB-19M-Adapter/images/DB19M_to_IDC20_Adapter.png" width="400px">
+[<img src="images/DB19M_to_IDC20_Adapter.png" width="400px" />](images/DB19M_to_IDC20_Adapter.png)
 
 # License
 
@@ -17,8 +17,8 @@ This project is released under the CERN OHL v2.0.
 
 Insert the 19 pins for the DB-19 socket into a DB-19 or DB-25 cable/adapter with the "fins" of the pins as shown below
 
-<img src="https://github.com/FujiNetWIFI/fujinet-hardware/blob/master/AppleII/DB-19M-Adapter/images/DB19M_to_IDC20_Pin-Alignment.png" width="300px">
-<img src="https://github.com/FujiNetWIFI/fujinet-hardware/blob/master/AppleII/DB-19M-Adapter/images/IMG_20221002_145542.jpg" width="300px">
+[<img src="images/DB19M_to_IDC20_Pin-Alignment.png" width="300px" />](images/DB19M_to_IDC20_Pin-Alignment.png)
+[<img src="images/IMG_20221002_145542.jpg" width="300px" />](images/IMG_20221002_145542.jpg)
 
 The PCB is labeled "PIN SIDE" which is where the 3D printed connector goes. The unlabled side of the PCB is the solder side. Solder pin 1 and pin 19 first, ensuring the pins are straight/flush with the PCB then solder the remaining pins. Use side cutters to remove excess pins from the solder side.
 
@@ -32,7 +32,7 @@ The design was created with Tinkercad: https://www.tinkercad.com/things/jGl5ZyhV
 
 # Usage
 
-The +12V and -12V lines are not connectoed by default to prevent accidental damage. If you need these lines connected, add a solder blob to the labeled pads. 
+The +12V and -12V lines are not connected by default to prevent accidental damage. If you need these lines connected, add a solder blob to the labeled pads.
 
 The Drive 2 pin is broke out to a solder pad if needed
 


### PR DESCRIPTION
I noticed the READMEs for the older versions of the Apple II hardware had broken embedded images. This fixes those.

Additionally, make resized images link to the full-size version.

Also fixes one typo.